### PR TITLE
Add an option to simply ignore unknown arguments

### DIFF
--- a/include/Support/CmdLine.h
+++ b/include/Support/CmdLine.h
@@ -93,7 +93,7 @@ public:
     void add(OptionBase& opt);
 
     // Parse the given command line arguments
-    void parse(StringVector const& argv, bool checkRequired = true);
+    void parse(StringVector const& argv, bool ignoreUnknown = false, bool checkRequired = true);
 
     // Returns whether all command line arguments have been processed
     bool empty() const;
@@ -114,7 +114,7 @@ public:
     std::string help(StringRef programName, StringRef overview = "") const;
 
 private:
-    void parse(bool checkRequired);
+    void parse(bool ignoreUnknown, bool checkRequired);
 
     OptionBase* findOption(StringRef name) const;
 

--- a/src/CmdLine.cpp
+++ b/src/CmdLine.cpp
@@ -104,14 +104,14 @@ void CmdLine::add(OptionBase& opt)
     }
 }
 
-void CmdLine::parse(StringVector const& argv, bool checkRequired)
+void CmdLine::parse(StringVector const& argv, bool ignoreUnknown, bool checkRequired)
 {
     // Save the list of arguments
     argCurr_ = argv.begin();
     argLast_ = argv.end();
 
     // Parse...
-    parse(checkRequired);
+    parse(ignoreUnknown, checkRequired);
 }
 
 bool CmdLine::empty() const
@@ -199,7 +199,7 @@ std::string CmdLine::help(StringRef programName, StringRef overview) const
     return result;
 }
 
-void CmdLine::parse(bool checkRequired)
+void CmdLine::parse(bool ignoreUnknown, bool checkRequired)
 {
     // "--" seen?
     auto dashdash = false;
@@ -210,7 +210,15 @@ void CmdLine::parse(bool checkRequired)
     // Handle all arguments
     while (!empty())
     {
-        handleArg(dashdash, pos);
+        try
+        {
+            handleArg(dashdash, pos);
+        }
+        catch (...)
+        {
+            if (!ignoreUnknown)
+                throw;
+        }
 
         bump();
     }


### PR DESCRIPTION
I need an option to silently ignore unknown arguments. Simply conditionally rethrowing the exceptions from the args parser functions is probably only suitable as far as those only throw due to an unhandled argument (which is currently the case), so I'm not sure if there is a better way to achieve this...